### PR TITLE
Travis CI failed on current build.

### DIFF
--- a/mafan/third_party/jianfan/__init__.py
+++ b/mafan/third_party/jianfan/__init__.py
@@ -45,7 +45,7 @@ def _t(unistr, charset_from, charset_to):
 
 
 def jtof(unicode_string):
-    """
+    u"""
         Translate simplified chinese to traditional chinese.
         >>> s = u'中华'
         >>> print jtof(s)
@@ -54,7 +54,7 @@ def jtof(unicode_string):
     return _t(unicode_string, gbk, big5)
 
 def ftoj(unicode_string):
-    """
+    u"""
         Translate traditional chinese to simplified chinese.
         >>> t = u'中華'
         >>> print ftoj(t)


### PR DESCRIPTION
Travis CI will failed while execute "nosetests --with-doctest". The test data of "nosetests" is from source code's comments. Therefore, the "nosetests" will capture input and expected output from comments. Consequently, if we didn't put prefix 'u' in front of annotation symbol """, the "nosetests" will consider comments type are ascii based.


